### PR TITLE
fix: add missing return in GetRequestID

### DIFF
--- a/content/stdlib/context/2-context 有什么作用.md
+++ b/content/stdlib/context/2-context 有什么作用.md
@@ -123,7 +123,7 @@ func WithRequestID(next http.Handler) http.Handler {
 
 // 获取 request-id
 func GetRequestID(ctx context.Context) string {
-	ctx.Value(requestIDKey).(string)
+	return ctx.Value(requestIDKey).(string)
 }
 
 func Handle(rw http.ResponseWriter, req *http.Request) {


### PR DESCRIPTION
### Issue
GetRequestID(ctx context.Context) string
function was missing a return statement. This caused a compile error:

    missing return at end of function

### Solution
Added a `return` statement so that the function correctly returns
the string value from the context.

```go
func GetRequestID(ctx context.Context) string {
    return ctx.Value(requestIDKey).(string)
}
